### PR TITLE
Adding support for commaBreak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the "pgFormatter" extension will be documented in this fi
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [1.5.2] - 2019-01-29
+
+### Changed
+
+* Add support for commaBreak
+
 ## [1.5.0] - 2018-09-12
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pgFormatter [![Build Status](https://travis-ci.org/bradymholt/vscode-pgFormatter.svg?branch=master)](https://travis-ci.org/bradymholt/vscode-pgFormatter)
 
-A VS Code extension that formats PostgresSQL SQL, using the Perl based [pgFormatter](https://github.com/darold/pgFormatter) tool developed by [Gilles Darold](https://github.com/darold).
+A VS Code extension that formats PostgreSQL SQL, using the Perl based [pgFormatter](https://github.com/darold/pgFormatter) tool developed by [Gilles Darold](https://github.com/darold).
 
 ## Features
 
@@ -31,6 +31,7 @@ This extension has the following configuration settings:
 * `pgFormatter.spaces` - Number of spaces to indent the code (Default: 2)
 * `pgFormatter.maxLength` - Maximum length of a query
 * `pgFormatter.commaStart` - Use preceding comma in parameter list (Default: false)
+* `pgFormatter.commaBreak` - In insert statement, add a newline after each comma (Default: false)
 * `pgFormatter.commaEnd` - Use trailing comma in parameter list (Default: true)
 * `pgFormatter.noComment` - Remove any comments (Default: false)
 * `pgFormatter.functionCase` - Case of the function names (Options: ["unchanged", "lowercase", "uppercase", "capitalize"]; Default: "unchanged")

--- a/package.json
+++ b/package.json
@@ -73,6 +73,11 @@
           "default": false,
           "description": "Use preceding comma in parameter list"
         },
+        "pgFormatter.commaBreak": {
+          "type": "boolean",
+          "default": false,
+          "description": "In insert statement, add a newline after each comma"
+        },
         "pgFormatter.commaEnd": {
           "type": "boolean",
           "default": true,

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "Brady Holt"
   },
-  "version": "1.5.1",
+  "version": "1.5.2",
   "publisher": "bradymholt",
   "icon": "icon.png",
   "galleryBanner": {


### PR DESCRIPTION
Hopefully I'm doing this correctly. My end goal is go be able to use this commaBreak configuration in the VS Code pgFormatter extension

I followed instructions you wrote in [this link](https://github.com/bradymholt/vscode-pgFormatter/issues/13#issuecomment-453630081).

My pull request that you merged earlier in the [psqlformat](https://github.com/bradymholt/psqlformat) project was what seemed to be the first step.

I'm hoping that this is the last step to use this in the VS Code's extension.