### PR TITLE
Add compatibility with ckolkman.vscode-postgres VS Code extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
   },
   "activationEvents": [
     "onLanguage:sql",
-    "onLanguage:pgsql"
+    "onLanguage:pgsql",
+    "onLanguage:postgres"
   ],
   "main": "./out/extension",
   "contributes": {
@@ -49,6 +50,17 @@
           "SQL",
           "sql",
           "pgsql"
+        ],
+        "extensions": [
+          "sql",
+          "pgsql"
+        ]
+      },
+      {
+        "id": "postgres",
+        "aliases": [
+          "PostgreSQL",
+          "Postgres"
         ],
         "extensions": [
           "sql",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -55,7 +55,7 @@ export function getFormattedText(
 export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.languages.registerDocumentFormattingEditProvider(
-      [{ language: "sql" }, { language: "pgsql" }],
+      [{ language: "sql" }, { language: "pgsql" }, { language: "postgres" }],
       {
         provideDocumentFormattingEdits
       }


### PR DESCRIPTION
[PostgreSQL Management Tool](https://marketplace.visualstudio.com/items?itemName=ckolkman.vscode-postgres) by Chris Kolkman adds a new "Postgres" language mode to VS Code which practically renders using any formatter aimed for the default "SQL" mode impossible