### PR TITLE
New wrapLimit option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pgformatter",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -48,15 +48,15 @@
       "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
     },
     "@types/mocha": {
-      "version": "5.2.7",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.7.tgz",
-      "integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-7.0.1.tgz",
+      "integrity": "sha512-L/Nw/2e5KUaprNJoRA33oly+M8X8n0K+FwLTbYqwTcR14wdPWeRkigBLfSFpN/Asf9ENZTMZwLxjtjeYucAA4Q==",
       "dev": true
     },
     "@types/node": {
-      "version": "13.5.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.5.0.tgz",
-      "integrity": "sha512-Onhn+z72D2O2Pb2ql2xukJ55rglumsVo1H6Fmyi8mlU9SvKdBk/pUSUAiBY/d9bAOF7VVWajX3sths/+g6ZiAQ=="
+      "version": "13.7.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.1.tgz",
+      "integrity": "sha512-Zq8gcQGmn4txQEJeiXo/KiLpon8TzAl0kmKH4zdWctPj05nWwp1ClMdAVEloqrQKfaC48PNLdgN/aVaLqUrluA=="
     },
     "agent-base": {
       "version": "4.3.0",
@@ -769,9 +769,9 @@
       "dev": true
     },
     "psqlformat": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/psqlformat/-/psqlformat-1.4.0.tgz",
-      "integrity": "sha512-C3+mLaBJl1xM25lhKlIKba14hJG5O/9tHR3/0tVemjQO+uo282aBO8lFrE3GPwdtF2EivWmUnszLhtzkf6Tdzw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/psqlformat/-/psqlformat-1.5.0.tgz",
+      "integrity": "sha512-AByiLH2arEn3DW8RKuzadItTRYXGBUBgFk8AWx8KM4Tzp/Bpx8mrEdvXrDbavJOrSXfmWTSIMrVtr7NMF9SVlw==",
       "requires": {
         "globby": "^10.0.1",
         "yargs": "^13.3.0"

--- a/package.json
+++ b/package.json
@@ -128,6 +128,10 @@
           "default": false,
           "description": "Use another formatting type for some statements"
         },
+        "pgFormatter.wrapLimit": {
+          "type": "number",          
+          "description": "Wrap queries at a certain length"
+        },
         "pgFormatter.placeholder": {
           "type": "string",
           "default": null,

--- a/package.json
+++ b/package.json
@@ -150,12 +150,12 @@
     "vscode:publish": "vsce publish"
   },
   "devDependencies": {
-    "@types/mocha": "^5.2.7",
-    "@types/node": "^13.5.0",
+    "@types/mocha": "^7.0.1",
+    "@types/node": "^13.7.1",
     "typescript": "^3.7.5",
     "vscode": "^1.1.36"
   },
   "dependencies": {
-    "psqlformat": "^1.4.0"
+    "psqlformat": "^1.5.0"
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -43,6 +43,7 @@ export function getFormattedText(
       formattingOptions.spaces = Number(options.tabSize);
     }
 
+    addToOutput(`Formatting with options ${JSON.stringify(formattingOptions)}:`)
     let formatted = formatSql(text, formattingOptions);
     return formatted;
   } catch (err) {

--- a/src/outputHandler.ts
+++ b/src/outputHandler.ts
@@ -15,6 +15,10 @@ let outputChannel: OutputChannel;
  * @param message The message to append to the output channel
  */
 export function addToOutput(message: string): void {
+  if (!outputChannel){
+    return;
+  }
+  
   const title = `${new Date().toLocaleString()}:`;
 
   // Create a sort of title, to differentiate between messages


### PR DESCRIPTION
Adding new `wrapLimit` parameter which maps to wrap-limit on [pgFormatter](https://github.com/darold/pgFormatter/blob/master/README) and "wrap queries at a certain length".

>  -w | --wrap-limit N   : wrap queries at a certain length.