### PR TITLE
Substitute variables in extraFunction

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -62,6 +62,9 @@ export function getFormattedText(
         config.pgFormatterPath
       );
     }
+    if (config.extraFunction != null) {
+      formattingOptions.extraFunction = substituteVariables(config.extraFunction);
+    }
 
     addToOutput(
       `Formatting with options ${JSON.stringify(formattingOptions)}:`


### PR DESCRIPTION
The `extraFunction` option is the only option that accepts a path, but does not support variable substitution. This PR updates it to match `configFile`.

For context, we want to use the following VSCode config which requires `extraFunction` to be templatable.

```
"pgFormatter.configFile": "${workspaceFolder}/db/pg_format/pg_format.conf",
"pgFormatter.extraFunction": "${workspaceFolder}/db/pg_format/extra_functions.txt",
```

We already specify `extra-function` in our `pg_format.conf`, but that filepath is not resolved relative to the workspace root, so we need to override it with `pgFormatter.extraFunction`.